### PR TITLE
Correct command line spoiler generation

### DIFF
--- a/src/main-spoil.c
+++ b/src/main-spoil.c
@@ -18,9 +18,14 @@
 
 #ifdef USE_SPOIL
 
+#include "datafile.h"
+#include "game-world.h"
 #include "init.h"
 #include "main.h"
+#include "obj-init.h"
 #include "player-birth.h"
+#include "savefile.h"
+#include "ui-game.h"
 #include "wizard.h"
 
 static struct {
@@ -37,20 +42,97 @@ static struct {
 
 const char help_spoil[] =
 	"Spoiler generation mode, subopts\n"
-	"              -a fname    Write artifact spoilers to fname\n"
+	"              -a fname    Write artifact spoilers to fname;\n"
+	"                          if neither -p nor -u are used, uses the\n"
+	"                          standard artifacts\n"
 	"              -m fname    Write brief monster spoilers to fname\n"
 	"              -M fname    Write extended monster spoilers to fname\n"
-	"              -o fname    Write object spoilers to fname";
+	"              -o fname    Write object spoilers to fname\n"
+	"              -p          Use the artifacts associated with the\n"
+	"                          the savefile set by main.c\n"
+	"              -r fname    Use the randart file, fname, as the source\n"
+	"                          of the artifacts";
+
+static bool copy_file(const char *src, const char *dest, file_type ft)
+{
+	ang_file *fin = file_open(src, MODE_READ, -1);
+	ang_file *fout;
+	char buf[1024];
+	bool result;
+
+	if (!fin) {
+		return false;
+	}
+
+	fout = file_open(dest, MODE_WRITE, ft);
+	if (!fout) {
+		(void) file_close(fin);
+		return false;
+	}
+
+	result = true;
+	while (1) {
+		int nin = file_read(fin, buf, sizeof(buf));
+
+		if (nin > 0) {
+			if (!file_write(fout, buf, nin)) {
+				result = false;
+				break;
+			}
+		} else {
+			if (nin < 0) {
+				result = false;
+			}
+			break;
+		}
+	}
+
+	if (!file_close(fout)) {
+		result = false;
+	}
+	if (!file_close(fin)) {
+		result = false;
+	}
+
+	return result;
+}
+
+/* Make an effort to get the seed from the supplied randart file. */
+static u32b parse_seed(const char *src)
+{
+	u32b result = 0;
+	ang_file *fin = file_open(src, MODE_READ, -1);
+
+	if (fin) {
+		char buf[256];
+		char *s;
+
+		if (file_getl(fin, buf, sizeof(buf)) &&
+				(s = my_stristr(buf, "seed"))) {
+			unsigned long ulv;
+
+			if (sscanf(s, "seed %lx", &ulv) == 1) {
+				result = (u32b)ulv;
+			}
+		}
+		(void) file_close(fin);
+	}
+	return result;
+}
 
 /**
  * Usage:
  *
- * angband -mspoil -- [-a fname] [-m fname] [-M fname] [-o fname]
+ * angband -mspoil -- [-a fname] [-m fname] [-M fname] [-o fname] \
+ *     [-p] [-r fname]
  *
- *   -a fname  Write artifact spoilers to a file named fname.
+ *   -a fname  Write artifact spoilers to a file named fname.  If neither -p or
+ *             -u are used, the artifacts will be the standard set.
  *   -m fname  Write brief monster spoilers to a file named fname.
  *   -M fname  Write extended monster spoilers to a file named fname.
  *   -o fname  Write object spoilers to a file named fname.
+ *   -p        Use the artifacts associated with savefile set by main.c.
+ *   -r fname  Use the randart file, fname, as the source of the artifacts.
  *
  * Bugs:
  * Would be nice to accept "-" as the file name and write the spoilers to
@@ -67,6 +149,8 @@ errr init_spoil(int argc, char *argv[]) {
 	/* Skip over argv[0] */
 	int i = 1;
 	int result = 0;
+	bool load_randart = false;
+	const char *randart_name = NULL;
 
 	/* Parse the arguments. */
 	while (1) {
@@ -79,32 +163,49 @@ errr init_spoil(int argc, char *argv[]) {
 
 		if (argv[i][0] == '-') {
 			/* Try to match with a known option. */
-			int j = 0;
-
-			while (1) {
-				if (j >= (int)N_ELEMENTS(opts)) {
-					badarg = true;
-					break;
+			if (argv[i][1] == 'p' && argv[i][2] == '\0') {
+				load_randart = true;
+				randart_name = NULL;
+			} else if (argv[i][1] == 'r' && argv[i][2] == '\0') {
+				if (i < argc - 1) {
+					load_randart = true;
+					/* Record the name; don't parse it. */
+					randart_name = argv[i + 1];
+					++increment;
+				} else {
+					printf("init-spoil: '%s' requires an argument, the name of a randart file\n", argv[i]);
+					result = 1;
 				}
+			} else {
+				int j = 0;
 
-				if (argv[i][1] == opts[j].letter &&
-					argv[i][2] == '\0') {
-					if (i < argc - 1) {
-						opts[j].enabled = true;
-						/*
-						 * Record the filename and
-						 * skip parsing of it.
-						 */
-						opts[j].path = argv[i + 1];
-						++increment;
-					} else {
-						printf("init-spoil: '%s' requires an argument, the name of the spoiler file\n", argv[i]);
-						result = 1;
+				while (1) {
+					if (j >= (int)N_ELEMENTS(opts)) {
+						badarg = true;
+						break;
 					}
-					break;
-				}
 
-				++j;
+					if (argv[i][1] == opts[j].letter &&
+							argv[i][2] == '\0') {
+						if (i < argc - 1) {
+							opts[j].enabled = true;
+							/*
+							 * Record the filename
+							 * and skip parsing
+							 * of it.
+							 */
+							opts[j].path =
+								argv[i + 1];
+							++increment;
+						} else {
+							printf("init-spoil: '%s' requires an argument, the name of the spoiler file\n", argv[i]);
+							result = 1;
+						}
+						break;
+					}
+
+					++j;
+				}
 			}
 		} else {
 			badarg = true;
@@ -121,15 +222,64 @@ errr init_spoil(int argc, char *argv[]) {
 	if (result == 0) {
 		/* Generate the spoilers. */
 		init_angband();
-		player_generate(player, races, classes, false);
 
-		for (i = 0; i < (int)N_ELEMENTS(opts); ++i) {
-			if (!opts[i].enabled) continue;
-			(*(opts[i].func))(opts[i].path);
+		if (load_randart) {
+			deactivate_randart_file();
+			if (randart_name) {
+				char defname[1024];
+
+				path_build(defname, sizeof(defname),
+					ANGBAND_DIR_USER, "randart.txt");
+				/*
+				 * Copy rather than move in case the file
+				 * supplied is read-only.
+				 */
+				if (copy_file(randart_name, defname, FTYPE_TEXT)) {
+					seed_randart =
+						parse_seed(randart_name);
+
+					cleanup_parser(&artifact_parser);
+					run_parser(&randart_parser);
+					file_delete(defname);
+
+					player_generate(player, races, classes, false);
+				} else {
+					printf("init-spoil: could not copy randart file to '%s'.\n", defname);
+					result = 1;
+				}
+			} else if (file_exists(savefile)) {
+				bool loaded_save =
+					savefile_load(savefile, false);
+
+				deactivate_randart_file();
+				if (!loaded_save) {
+					printf("init-spoil: using artifacts associated with a savefile, but the savefile set by main, '%s', failed to load.\n", savefile);
+					result = 1;
+				}
+			} else {
+				if (savefile[0]) {
+					printf("init-spoil: using artifacts associated with a savefile, but the savefile set by main, '%s', does not exist.\n", savefile);
+				} else {
+					printf("init-spoil: using artifacts associated with a savefile, but main did not set the savefile\n");
+				}
+				result = 1;
+			}
+		} else {
+			player_generate(player, races, classes, false);
+		}
+
+		if (result == 0) {
+			for (i = 0; i < (int)N_ELEMENTS(opts); ++i) {
+				if (!opts[i].enabled) continue;
+				(*(opts[i].func))(opts[i].path);
+			}
 		}
 
 		cleanup_angband();
-		exit(0);
+
+		if (result == 0) {
+			exit(0);
+		}
 	}
 
 	return result;

--- a/src/main.c
+++ b/src/main.c
@@ -503,21 +503,6 @@ int main(int argc, char *argv[])
 	}
 #endif
 
-	/* Try the modules in the order specified by modules[] */
-	for (i = 0; i < (int)N_ELEMENTS(modules); i++) {
-		/* User requested a specific module? */
-		if (!mstr || (streq(mstr, modules[i].name))) {
-			ANGBAND_SYS = modules[i].name;
-			if (0 == modules[i].init(argc, argv)) {
-				done = true;
-				break;
-			}
-		}
-	}
-
-	/* Make sure we have a display! */
-	if (!done) quit("Unable to prepare any 'display module'!");
-
 #ifdef UNIX
 
 	/* Get the "user name" as default player name, unless set with -u switch */
@@ -532,6 +517,21 @@ int main(int argc, char *argv[])
 	create_needed_dirs();
 
 #endif /* UNIX */
+
+	/* Try the modules in the order specified by modules[] */
+	for (i = 0; i < (int)N_ELEMENTS(modules); i++) {
+		/* User requested a specific module? */
+		if (!mstr || (streq(mstr, modules[i].name))) {
+			ANGBAND_SYS = modules[i].name;
+			if (0 == modules[i].init(argc, argv)) {
+				done = true;
+				break;
+			}
+		}
+	}
+
+	/* Make sure we have a display! */
+	if (!done) quit("Unable to prepare any 'display module'!");
 
 	/* Catch nasty signals */
 	signals_init();


### PR DESCRIPTION
- Allow generation of spoilers for randarts:  initial version only used the standard set
- Change the player initialization so the name, cost, and power in the object or artifact spoiler files are more useful.